### PR TITLE
Add worktree-based hotfix flow

### DIFF
--- a/documentation/hotfix-flow.md
+++ b/documentation/hotfix-flow.md
@@ -1,0 +1,77 @@
+# Hotfix Flow — Worktree-based
+
+**Script:** `scripts/hotfix.ps1`
+**Stack:** Strapi 5 / TypeScript, shared local PostgreSQL (`suyai_bd`), dev server on `PORT=1337`.
+
+> Use this when an urgent fix lands while you're mid-feature and your main
+> `npm run develop` is running. A worktree gives you an isolated working tree +
+> a second dev server **without** stopping your current work or stashing.
+
+---
+
+## TL;DR
+
+```powershell
+./scripts/hotfix.ps1 new <name>          # create worktree on hotfix/<name> @ :1338
+cd ../back-hotfix-<name>
+npm run develop                          # http://localhost:1338/admin
+# fix → commit → push → PR
+cd ../back
+./scripts/hotfix.ps1 done <name>         # remove worktree, KEEP branch for the PR
+```
+
+---
+
+## Commands
+
+| Command | What it does |
+|---------|--------------|
+| `new <name>` | Fetches `origin`, creates worktree `../back-hotfix-<name>` on branch `hotfix/<name>` from `origin/main`, wires up `.env` + `node_modules`. |
+| `done <name>` | Removes the worktree (and its `node_modules` junction). **Branch is kept** so its PR survives. |
+| `list` | `git worktree list` — show active worktrees. |
+
+### Flags (for `new`)
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `-Port <n>` | `1338` | Port for the worktree's dev server (so it runs alongside `:1337`). |
+| `-Install` | off | Run a clean `npm install` instead of junction-linking `node_modules`. Use when the hotfix needs a new/changed dependency. |
+| `-Base <ref>` | `origin/main` | Branch the hotfix off something other than `origin/main`. |
+
+---
+
+## What it handles (project-specific gotchas)
+
+- **`.env` is gitignored** → copied into the worktree, with `PORT` rewritten to `-Port`
+  so both servers run at once.
+- **`node_modules` is gitignored and Strapi is heavy** → junction-linked from the main
+  repo (instant, zero extra GB). `done` removes only the link, never the real folder.
+- **Shared local PostgreSQL (`suyai_bd`)** → the worktree hits the **same DB** as your
+  main server. Good for a hotfix (real data), with one caveat below.
+
+---
+
+## ⚠️ Caveats
+
+- **No schema/content-type changes in a hotfix worktree.** Two Strapi instances
+  against one PostgreSQL DB will fight over migrations. Keep hotfixes to code
+  (controllers, services, lifecycles, templates) — not content-type definitions.
+- **Junction assumes deps match `main`.** If the fix adds or bumps a package, run
+  `new` with `-Install` so the worktree gets its own real `node_modules`.
+- Worktrees live as siblings: `D:\Projects\suyai\back-hotfix-<name>`.
+
+---
+
+## Manual fallback
+
+If the script is unavailable:
+
+```powershell
+git fetch origin
+git worktree add -b hotfix/x ../back-hotfix-x origin/main
+Copy-Item .env ../back-hotfix-x/.env          # then edit PORT
+New-Item -ItemType Junction -Path ../back-hotfix-x/node_modules -Target ./node_modules
+# ... work ...
+cmd /c rmdir ../back-hotfix-x/node_modules    # drop junction first
+git worktree remove ../back-hotfix-x --force
+```

--- a/scripts/hotfix.ps1
+++ b/scripts/hotfix.ps1
@@ -1,0 +1,142 @@
+<#
+.SYNOPSIS
+  Worktree-based hotfix flow for the Suyai backend (Strapi 5).
+
+.DESCRIPTION
+  Spins up an isolated git worktree off origin/main so you can fix something
+  urgent WITHOUT touching your current working tree or stopping your main
+  `npm run develop` server.
+
+  Handles the project-specific gotchas:
+    - .env is gitignored        -> copied into the worktree
+    - PORT=1337 would clash      -> overridden (default 1338) so both run at once
+    - node_modules is gitignored -> junction-linked from main repo (instant),
+                                     or full install with -Install
+    - DB is shared local postgres (suyai_bd) -> worktree hits the SAME db.
+      Fine for a hotfix (real data). Avoid schema/content-type changes in a
+      hotfix worktree, since two Strapi instances would fight over migrations.
+
+.EXAMPLE
+  ./scripts/hotfix.ps1 new email-typo
+  # creates ../back-hotfix-email-typo on branch hotfix/email-typo, port 1338
+
+.EXAMPLE
+  ./scripts/hotfix.ps1 new email-typo -Port 1339 -Install
+  # custom port + clean npm install instead of junction
+
+.EXAMPLE
+  ./scripts/hotfix.ps1 done email-typo
+  # removes the worktree (branch is kept for the PR)
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory, Position = 0)]
+  [ValidateSet('new', 'done', 'list')]
+  [string]$Command,
+
+  [Parameter(Position = 1)]
+  [string]$Name,
+
+  [int]$Port = 1338,
+
+  [switch]$Install,
+
+  [string]$Base = 'origin/main'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Repo root = parent of this scripts/ folder
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$ProjectName = Split-Path -Leaf $RepoRoot          # "back"
+$ParentDir = Split-Path -Parent $RepoRoot
+
+function Get-WorktreePath([string]$n) {
+  Join-Path $ParentDir "$ProjectName-hotfix-$n"
+}
+
+switch ($Command) {
+
+  'list' {
+    git -C $RepoRoot worktree list
+    break
+  }
+
+  'new' {
+    if (-not $Name) { throw "Usage: hotfix.ps1 new <name>" }
+
+    $branch = "hotfix/$Name"
+    $wt = Get-WorktreePath $Name
+
+    if (Test-Path $wt) { throw "Worktree path already exists: $wt" }
+
+    Write-Host "==> Fetching origin..." -ForegroundColor Cyan
+    git -C $RepoRoot fetch origin --quiet
+
+    Write-Host "==> Creating worktree $wt on $branch (from $Base)" -ForegroundColor Cyan
+    git -C $RepoRoot worktree add -b $branch $wt $Base
+
+    # .env (gitignored) -> copy + override PORT for side-by-side running
+    $srcEnv = Join-Path $RepoRoot '.env'
+    $dstEnv = Join-Path $wt '.env'
+    if (Test-Path $srcEnv) {
+      Write-Host "==> Copying .env and setting PORT=$Port" -ForegroundColor Cyan
+      $env = Get-Content $srcEnv
+      if ($env -match '^\s*PORT=') {
+        $env = $env -replace '^\s*PORT=.*', "PORT=$Port"
+      } else {
+        $env += "PORT=$Port"
+      }
+      Set-Content -Path $dstEnv -Value $env -Encoding UTF8
+    } else {
+      Write-Warning ".env not found in main repo — worktree has no env file."
+    }
+
+    # node_modules (gitignored, heavy)
+    $srcNm = Join-Path $RepoRoot 'node_modules'
+    $dstNm = Join-Path $wt 'node_modules'
+    if ($Install) {
+      Write-Host "==> Installing dependencies (npm install)..." -ForegroundColor Cyan
+      Push-Location $wt
+      try { npm install } finally { Pop-Location }
+    }
+    elseif (Test-Path $srcNm) {
+      Write-Host "==> Junction-linking node_modules from main repo (instant)" -ForegroundColor Cyan
+      New-Item -ItemType Junction -Path $dstNm -Target $srcNm | Out-Null
+    }
+    else {
+      Write-Warning "No node_modules in main repo. Run with -Install or 'npm install' in the worktree."
+    }
+
+    Write-Host ""
+    Write-Host "Ready." -ForegroundColor Green
+    Write-Host "  cd `"$wt`""
+    Write-Host "  npm run develop      # serves on http://localhost:$Port/admin"
+    Write-Host ""
+    Write-Host "When done:  ./scripts/hotfix.ps1 done $Name" -ForegroundColor DarkGray
+    break
+  }
+
+  'done' {
+    if (-not $Name) { throw "Usage: hotfix.ps1 done <name>" }
+    $wt = Get-WorktreePath $Name
+
+    # Remove the junction first so worktree removal never follows it into the
+    # real node_modules.
+    $nm = Join-Path $wt 'node_modules'
+    if (Test-Path $nm) {
+      $item = Get-Item $nm -Force
+      if ($item.LinkType -eq 'Junction') {
+        Write-Host "==> Removing node_modules junction" -ForegroundColor Cyan
+        cmd /c rmdir "$nm" | Out-Null
+      }
+    }
+
+    Write-Host "==> Removing worktree $wt (branch hotfix/$Name kept)" -ForegroundColor Cyan
+    git -C $RepoRoot worktree remove $wt --force
+    git -C $RepoRoot worktree prune
+
+    Write-Host "Done. Branch hotfix/$Name still exists for its PR." -ForegroundColor Green
+    break
+  }
+}


### PR DESCRIPTION
## What

Adds a worktree-based hotfix flow so an urgent fix can run **alongside** the main `npm run develop` server without stopping it or stashing in-progress work.

- `scripts/hotfix.ps1` — `new` / `done` / `list` commands
- `documentation/hotfix-flow.md` — usage, flags, caveats

## How it handles project gotchas

- **`.env` gitignored** → copied into the worktree with `PORT` overridden (default `1338`) so both dev servers run at once
- **`node_modules` gitignored + Strapi heavy** → junction-linked from the main repo (instant, no reinstall); `done` removes only the link, never the real folder
- **Shared local PostgreSQL (`suyai_bd`)** → worktree hits the same DB (good for hotfixes); documented caveat to avoid schema/content-type changes since two Strapi instances would fight over migrations

## Usage

```powershell
./scripts/hotfix.ps1 new email-typo     # worktree on hotfix/email-typo @ :1338
cd ../back-hotfix-email-typo
npm run develop
# fix → commit → push → PR
./scripts/hotfix.ps1 done email-typo     # remove worktree, keep branch
```

## Verified

Tested create → run → teardown end-to-end: `.env` PORT rewrite ✓, `node_modules` junction ✓, teardown leaves main `node_modules` intact and keeps the branch ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)