### PR TITLE
fix/Migrate email provider from SendGrid to Resend

### DIFF
--- a/config/plugins.ts
+++ b/config/plugins.ts
@@ -37,13 +37,19 @@ export default ({ env }) => ({
   },
   email: {
     config: {
-      provider: 'sendgrid', // For community providers pass the full package name (e.g. provider: 'strapi-provider-email-mandrill')
+      provider: 'nodemailer',
       providerOptions: {
-        apiKey: env('SMTP_APIKEY'),
+        host: env('SMTP_HOST', 'smtp.resend.com'),
+        port: env.int('SMTP_PORT', 465),
+        secure: env.bool('SMTP_SECURE', true),
+        auth: {
+          user: env('SMTP_USERNAME', 'resend'),
+          pass: env('RESEND_API_KEY'),
+        },
       },
       settings: {
-        defaultFrom: env('SMTP_EMAIL'),
-        defaultReplyTo: env('SMTP_EMAIL'),
+        defaultFrom: env('SMTP_FROM'),
+        defaultReplyTo: env('SMTP_FROM'),
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@strapi/plugin-graphql": "^5.9.0",
     "@strapi/plugin-seo": "^2.0.8",
     "@strapi/plugin-users-permissions": "5.4.1",
+    "@strapi/provider-email-nodemailer": "^5.48.1",
     "@strapi/provider-email-sendgrid": "^5.12.3",
     "@strapi/provider-upload-cloudinary": "^5.11.0",
     "@strapi/strapi": "^5.10.2",

--- a/src/api/form-contact/content-types/form-contact/lifecycles.ts
+++ b/src/api/form-contact/content-types/form-contact/lifecycles.ts
@@ -35,15 +35,17 @@ export default {
         // Send the email
         await strapi.plugins['email'].services.email.send({
           to: result.email,
-          from: env.SMTP_EMAIL_ADMIN,
-          subject: 'Cotacto recibido',
+          from: env.SMTP_FROM,
+          replyTo: env.SMTP_EMAIL_ADMIN,
+          subject: 'Contacto recibido',
           html: emailTemplate,
         });
 
         // Send copy email
         await strapi.plugins['email'].services.email.send({
           to: env.SMTP_EMAIL_ADMIN,
-          from: env.SMTP_EMAIL_ADMIN,
+          from: env.SMTP_FROM,
+          replyTo: result.email,
           subject: 'Contacto Copía',
           html: emailTemplateCopy,
         });

--- a/src/api/form-reservation-tour/content-types/form-reservation-tour/lifecycles.ts
+++ b/src/api/form-reservation-tour/content-types/form-reservation-tour/lifecycles.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { env } from 'process';
 export default {
   async afterCreate(event) {
     const { result } = event;
@@ -36,8 +37,9 @@ export default {
         // Send the email
         await strapi.plugins['email'].services.email.send({
           to: result.email,
-          from: 'noreply@mainstylis.com',
-          subject: 'The Strapi Email plugin worked successfully',
+          from: env.SMTP_FROM,
+          replyTo: env.SMTP_EMAIL_ADMIN,
+          subject: 'Reservación de Tour recibida',
           html: emailTemplate,
         });
 

--- a/src/api/form-reservation-transfer/content-types/form-reservation-transfer/lifecycles.ts
+++ b/src/api/form-reservation-transfer/content-types/form-reservation-transfer/lifecycles.ts
@@ -40,7 +40,8 @@ export default {
         // Send the email
         await strapi.plugins['email'].services.email.send({
           to: result.email,
-          from: env.SMTP_EMAIL_ADMIN,
+          from: env.SMTP_FROM,
+          replyTo: env.SMTP_EMAIL_ADMIN,
           subject: 'Reservacion Transfer',
           html: emailTemplate,
         });
@@ -48,7 +49,8 @@ export default {
         // Send copy email
         await strapi.plugins['email'].services.email.send({
           to: env.SMTP_EMAIL_ADMIN,
-          from: env.SMTP_EMAIL_ADMIN,
+          from: env.SMTP_FROM,
+          replyTo: result.email,
           subject: 'Reservacion Transfer Copía',
           html: emailTemplateCopy,
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2595,6 +2595,13 @@
     url-join "4.0.1"
     yup "0.32.9"
 
+"@strapi/provider-email-nodemailer@^5.48.1":
+  version "5.48.1"
+  resolved "https://registry.yarnpkg.com/@strapi/provider-email-nodemailer/-/provider-email-nodemailer-5.48.1.tgz#969c7a002e05befe0fb7857d0c86876423733b0d"
+  integrity sha512-859WVl7zaKIcdVgyeID4FpQOBAjoTZ7VH9iLHWnnRfQU38L59brRcVHOZZuahUNgobmLie9GPL3gACAXUmCnHA==
+  dependencies:
+    nodemailer "8.0.5"
+
 "@strapi/provider-email-sendgrid@^5.12.3":
   version "5.12.3"
   resolved "https://registry.yarnpkg.com/@strapi/provider-email-sendgrid/-/provider-email-sendgrid-5.12.3.tgz#c18768dab17f963efb7bcbf93052e23b909cb07f"
@@ -8230,6 +8237,11 @@ nodemailer-shared@1.1.0:
   integrity sha512-68xW5LSyPWv8R0GLm6veAvm7E+XFXkVgvE3FW0FGxNMMZqMkPFeGDVALfR1DPdSfcoO36PnW7q5AAOgFImEZGg==
   dependencies:
     nodemailer-fetch "1.6.0"
+
+nodemailer@8.0.5:
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-8.0.5.tgz#2076fb2b5c1ccfe1c88f6e1aa47c0229ea642e0c"
+  integrity sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==
 
 nodemon@3.0.2:
   version "3.0.2"


### PR DESCRIPTION
## 📄 Title

fix/Migrate email provider from SendGrid to Resend

## 📝 Detailed Description

The SendGrid account's free trial expired, so every transactional email failed with `401 Unauthorized` (confirmed in Render logs). This migrates email sending to Resend over SMTP and normalizes the sender across all form lifecycles.

Key changes:
- `config/plugins.ts`: switch email provider to `nodemailer` pointing at Resend SMTP (`smtp.resend.com`), driven by `RESEND_API_KEY` / `SMTP_FROM`.
- All form lifecycles now send `from` the verified domain sender (`SMTP_FROM = noreply@transfersuyai.cl`) and set `replyTo`.
- Removed leftover hardcoded `noreply@mainstylis.com` and placeholder subject in the tour lifecycle.

## 📂 Affected Components

**View:**
- _(none)_

**Test:**
- _(none)_

## 🖼️ Assets

(No UI changes)

## ✅ Tests

(No new tests in this PR)

## 🧪 Test Plan

1. Ensure Render env vars are set: `RESEND_API_KEY`, `SMTP_FROM=noreply@transfersuyai.cl`, `SMTP_EMAIL_ADMIN`.
2. Submit a contact / tour / transfer form.
3. Verify the customer receives the email and admin gets the copy.
4. Render logs show no `Error sending email` / 401.

## ⚠️ Important Note

- Requires new env vars on Render (`RESEND_API_KEY`, `SMTP_FROM`) and the verified `transfersuyai.cl` domain in Resend.
- New dependency: `@strapi/provider-email-nodemailer`.

<!-- Release note: Transactional emails (contact/reservation forms) now send via Resend. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)