### PR TITLE
fix/Send email via Resend HTTP API (SMTP blocked on Render)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.0.0",
+    "resend": "^6.14.0",
     "styled-components": "^6.0.0"
   },
   "devDependencies": {

--- a/src/api/form-contact/content-types/form-contact/lifecycles.ts
+++ b/src/api/form-contact/content-types/form-contact/lifecycles.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { env } from 'process';
 import { renderTemplate } from '../../../../utils/render-template';
+import { sendEmail } from '../../../../utils/send-email';
 export default {
   async afterCreate(event) {
     const { result } = event;
@@ -28,7 +29,7 @@ export default {
         emailTemplateCopy = renderTemplate(emailTemplateCopy, templateVars);
 
         // Send the email
-        await strapi.plugins['email'].services.email.send({
+        await sendEmail({
           to: result.email,
           from: env.SMTP_FROM,
           replyTo: env.SMTP_EMAIL_ADMIN,
@@ -37,7 +38,7 @@ export default {
         });
 
         // Send copy email
-        await strapi.plugins['email'].services.email.send({
+        await sendEmail({
           to: env.SMTP_EMAIL_ADMIN,
           from: env.SMTP_FROM,
           replyTo: result.email,

--- a/src/api/form-reservation-tour/content-types/form-reservation-tour/lifecycles.ts
+++ b/src/api/form-reservation-tour/content-types/form-reservation-tour/lifecycles.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { env } from 'process';
 import { renderTemplate } from '../../../../utils/render-template';
+import { sendEmail } from '../../../../utils/send-email';
 export default {
   async afterCreate(event) {
     const { result } = event;
@@ -36,11 +37,20 @@ export default {
         });
 
         // Send the email
-        await strapi.plugins['email'].services.email.send({
+        await sendEmail({
           to: result.email,
           from: env.SMTP_FROM,
           replyTo: env.SMTP_EMAIL_ADMIN,
           subject: 'Reservación de Tour recibida',
+          html: emailTemplate,
+        });
+
+        // Send copy email to admin
+        await sendEmail({
+          to: env.SMTP_EMAIL_ADMIN,
+          from: env.SMTP_FROM,
+          replyTo: result.email,
+          subject: 'Reservación de Tour Copía',
           html: emailTemplate,
         });
 

--- a/src/api/form-reservation-transfer/content-types/form-reservation-transfer/lifecycles.ts
+++ b/src/api/form-reservation-transfer/content-types/form-reservation-transfer/lifecycles.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { env } from 'process';
 import { renderTemplate } from '../../../../utils/render-template';
+import { sendEmail } from '../../../../utils/send-email';
 export default {
   async afterCreate(event) {
     const { result } = event;
@@ -31,7 +32,7 @@ export default {
 
 
         // Send the email
-        await strapi.plugins['email'].services.email.send({
+        await sendEmail({
           to: result.email,
           from: env.SMTP_FROM,
           replyTo: env.SMTP_EMAIL_ADMIN,
@@ -40,7 +41,7 @@ export default {
         });
 
         // Send copy email
-        await strapi.plugins['email'].services.email.send({
+        await sendEmail({
           to: env.SMTP_EMAIL_ADMIN,
           from: env.SMTP_FROM,
           replyTo: result.email,

--- a/src/utils/send-email.ts
+++ b/src/utils/send-email.ts
@@ -1,0 +1,39 @@
+import { Resend } from 'resend';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+interface SendEmailOptions {
+  to: string;
+  from?: string;
+  replyTo?: string;
+  subject: string;
+  html: string;
+}
+
+/**
+ * Send a transactional email through the Resend HTTP API (port 443).
+ *
+ * Render blocks outbound SMTP ports (25/465/587), so SMTP transports time out
+ * with ETIMEDOUT. The HTTP API is the only reliable transport on Render.
+ *
+ * Throws on API error so callers keep their existing try/catch logging.
+ */
+export const sendEmail = async (options: SendEmailOptions): Promise<void> => {
+  const { to, from = process.env.SMTP_FROM, replyTo, subject, html } = options;
+
+  if (!from) {
+    throw new Error('Missing sender address: set SMTP_FROM or pass `from`.');
+  }
+
+  const { error } = await resend.emails.send({
+    from,
+    to,
+    replyTo,
+    subject,
+    html,
+  });
+
+  if (error) {
+    throw new Error(`Resend error: ${error.message ?? JSON.stringify(error)}`);
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2197,6 +2197,11 @@
     escape-string-regexp "^2.0.0"
     lodash.deburr "^4.1.0"
 
+"@stablelib/base64@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/base64/-/base64-1.0.1.tgz#bdfc1c6d3a62d7a3b7bbc65b6cce1bb4561641be"
+  integrity sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==
+
 "@standard-schema/spec@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
@@ -6020,6 +6025,11 @@ fast-safe-stringify@2.1.1:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
+fast-sha256@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-sha256/-/fast-sha256-1.3.0.tgz#7916ba2054eeb255982608cccd0f6660c79b7ae6"
+  integrity sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==
+
 fast-uri@^3.0.1:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.6.tgz#88f130b77cfaea2378d56bf970dea21257a68748"
@@ -9224,6 +9234,11 @@ pony-cause@^2.1.4:
   resolved "https://registry.yarnpkg.com/pony-cause/-/pony-cause-2.1.11.tgz#d69a20aaccdb3bdb8f74dd59e5c68d8e6772e4bd"
   integrity sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg==
 
+postal-mime@2.7.4:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/postal-mime/-/postal-mime-2.7.4.tgz#3718d1f188357ed86f906f1db8d4ca455efa4927"
+  integrity sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==
+
 postcss-modules-extract-imports@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz#b4497cb85a9c0c4b5aabeb759bb25e8d89f15002"
@@ -9906,6 +9921,14 @@ reselect@^4.1.8:
   version "4.1.8"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.8.tgz#3f5dc671ea168dccdeb3e141236f69f02eaec524"
   integrity sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==
+
+resend@^6.14.0:
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/resend/-/resend-6.14.0.tgz#c052238b31a981a14441646056c6e3dd541ba015"
+  integrity sha512-jVdpUgOoWGLjaP64lo8KwzHT9gY4w6Dl8c36CIb2F+ayYOMLr3khqs8xrNjXM2k19b+lPoj0VWQFhVNLiToBjA==
+  dependencies:
+    postal-mime "2.7.4"
+    standardwebhooks "1.0.0"
 
 resolve-alpn@^1.0.0:
   version "1.2.1"
@@ -10604,6 +10627,14 @@ stackframe@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.3.4.tgz#b881a004c8c149a5e8efef37d51b16e412943310"
   integrity sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==
+
+standardwebhooks@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/standardwebhooks/-/standardwebhooks-1.0.0.tgz#5faa23ceacbf9accd344361101d9e3033b64324f"
+  integrity sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==
+  dependencies:
+    "@stablelib/base64" "^1.0.0"
+    fast-sha256 "^1.3.0"
 
 statuses@2.0.1:
   version "2.0.1"


### PR DESCRIPTION
## 📄 Title

fix/Send email via Resend HTTP API (SMTP blocked on Render)

## 📝 Detailed Description

After migrating to Resend over SMTP (#31), form submissions hung on submit and Render logs showed `Error: Connection timeout` / `ETIMEDOUT` on `CONN`. Render blocks outbound SMTP ports (25/465/587) across all plans, so any SMTP transport times out. This switches sending to the Resend HTTP API (port 443) via the official `resend` SDK.

Key changes:
- New `src/utils/send-email.ts`: thin wrapper over the Resend SDK, throws on API error so existing try/catch logging still works.
- `form-contact`, `form-reservation-tour`, `form-reservation-transfer` lifecycles now call `sendEmail(...)` instead of `strapi.plugins['email'].services.email.send(...)`.
- Restored the admin copy for tour reservations (the commit was lost because #31 merged just before it landed).

## 📂 Affected Components

**View:**
- _(none)_

**Test:**
- _(none)_

## 🖼️ Assets

(No UI changes)

## ✅ Tests

(No new tests in this PR)

## 🧪 Test Plan

1. Env vars on Render: `RESEND_API_KEY`, `SMTP_FROM=noreply@transfersuyai.cl`, `SMTP_EMAIL_ADMIN`.
2. Submit a contact / tour / transfer form on https://transfersuyai.cl.
3. Customer receives email; admin (`transuyai@gmail.com`) receives copy for all three forms.
4. Render logs show no `Error sending email` / ETIMEDOUT.

## ⚠️ Important Note

- The SMTP env vars (`SMTP_HOST/PORT/USERNAME/SECURE/PASSWORD`) are no longer used and can be removed from Render.
- New dependency: `resend`.

<!-- Release note: Transactional form emails now send through the Resend HTTP API (SMTP is blocked on Render). -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)