### PR TITLE
feat(destination): Destination collection type + home.destinations relation (#19, #25)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,4 +131,9 @@ exports
 dist
 build
 .strapi-updater.json
-.strapi-cloud.json
+.strapi-cloud.jsonKICKOFF.md
+
+# worktree kickoff brief — never commit
+KICKOFF.md
+# bun artifact (repo uses yarn)
+bun.lockb

--- a/src/api/destination/content-types/destination/schema.json
+++ b/src/api/destination/content-types/destination/schema.json
@@ -1,0 +1,40 @@
+{
+  "kind": "collectionType",
+  "collectionName": "destinations",
+  "info": {
+    "singularName": "destination",
+    "pluralName": "destinations",
+    "displayName": "Destination",
+    "description": "Travel destinations shown in tiles and the search dropdown"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "name"
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "images"
+      ]
+    },
+    "showInSearch": {
+      "type": "boolean",
+      "default": false,
+      "required": true
+    },
+    "order": {
+      "type": "integer"
+    }
+  }
+}

--- a/src/api/destination/controllers/destination.ts
+++ b/src/api/destination/controllers/destination.ts
@@ -1,0 +1,7 @@
+/**
+ * destination controller
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::destination.destination');

--- a/src/api/destination/routes/destination.ts
+++ b/src/api/destination/routes/destination.ts
@@ -1,0 +1,7 @@
+/**
+ * destination router
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::destination.destination');

--- a/src/api/destination/services/destination.ts
+++ b/src/api/destination/services/destination.ts
@@ -1,0 +1,7 @@
+/**
+ * destination service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::destination.destination');

--- a/src/api/home/content-types/home/schema.json
+++ b/src/api/home/content-types/home/schema.json
@@ -60,6 +60,11 @@
       "type": "component",
       "repeatable": false,
       "component": "shared.seo"
+    },
+    "destinations": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::destination.destination"
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -482,6 +482,41 @@ export interface ApiCategoryCategory extends Struct.CollectionTypeSchema {
   };
 }
 
+export interface ApiDestinationDestination extends Struct.CollectionTypeSchema {
+  collectionName: 'destinations';
+  info: {
+    description: 'Travel destinations shown in tiles and the search dropdown';
+    displayName: 'Destination';
+    pluralName: 'destinations';
+    singularName: 'destination';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    image: Schema.Attribute.Media<'images'>;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::destination.destination'
+    > &
+      Schema.Attribute.Private;
+    name: Schema.Attribute.String & Schema.Attribute.Required;
+    order: Schema.Attribute.Integer;
+    publishedAt: Schema.Attribute.DateTime;
+    showInSearch: Schema.Attribute.Boolean &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<false>;
+    slug: Schema.Attribute.UID<'name'>;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
 export interface ApiFooterFooter extends Struct.SingleTypeSchema {
   collectionName: 'footers';
   info: {
@@ -720,6 +755,10 @@ export interface ApiHomeHome extends Struct.SingleTypeSchema {
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
+    destinations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::destination.destination'
+    >;
     footer: Schema.Attribute.Component<'utils.footer', false>;
     form_reservation: Schema.Attribute.Component<'commons.form-section', false>;
     hero: Schema.Attribute.Component<'utils.hero', false>;
@@ -1476,6 +1515,7 @@ declare module '@strapi/strapi' {
       'api::article.article': ApiArticleArticle;
       'api::author.author': ApiAuthorAuthor;
       'api::category.category': ApiCategoryCategory;
+      'api::destination.destination': ApiDestinationDestination;
       'api::footer.footer': ApiFooterFooter;
       'api::form-contact.form-contact': ApiFormContactFormContact;
       'api::form-reservation-tour.form-reservation-tour': ApiFormReservationTourFormReservationTour;


### PR DESCRIPTION
## 📝 Detailed Description

Adds the `Destination` content type and exposes it to the frontend via GraphQL, unblocking FE #26 (search tiles / dropdown) and laying groundwork for FE #12 (reservation form dropdown). Closes #19 and #25.

Key changes:
- New **`Destination` collection type** (`api::destination.destination`) with the fields the tiles/dropdown need.
- **`home.destinations`** one-way `oneToMany` relation, so destinations are reachable through the Home single type without coupling `Destination` to Home.
- Regenerated Strapi content-type types.

## 📂 Affected Components

**API / Schema:**
- `src/api/destination/content-types/destination/schema.json`
- `src/api/destination/controllers/destination.ts`
- `src/api/destination/routes/destination.ts`
- `src/api/destination/services/destination.ts`
- `src/api/home/content-types/home/schema.json` (added `destinations` relation)
- `types/generated/contentTypes.d.ts` (regenerated)

**Test:**
- _(none)_

## 🧩 GraphQL Contract (locked for FE)

GraphQL type: **`Destination`**

| Field | Type | Notes |
|-------|------|-------|
| `documentId` | `ID!` | Strapi default |
| `name` | `String!` | required |
| `slug` | `String` | uid, from `name` |
| `image` | `UploadFile` | single image |
| `showInSearch` | `Boolean!` | default `false` |
| `order` | `Int` | sort key |
| `createdAt` / `updatedAt` / `publishedAt` | `DateTime` | defaults |

```graphql
# tiles / dropdown
destinations(filters: { showInSearch: { eq: true } }, sort: "order:asc") {
  documentId name slug order image { url alternativeText }
}

# via home single type
home { destinations { documentId name slug image { url } } }
```

## 🖼️ Assets
- _(No UI changes — backend only)_

## ✅ Tests
- _(No automated tests in this PR)_ — verified manually against a local postgres instance: GraphQL introspection confirms the `Destination` type, `home.destinations` field, and `DestinationFiltersInput.showInSearch`; seeded entries return correctly filtered/sorted results.

## 🧪 Test Plan

Type: **feat** — exercise the new type end-to-end.

1. Boot Strapi (`yarn develop`) against postgres.
2. In Strapi admin → **Settings → Users & Permissions → Roles → Public**, enable `find` + `findOne` for **Destination**, Save.
3. Create a few **Destination** entries, set `showInSearch`/`order`, and **Publish** them.
4. POST to `/graphql`:
   ```graphql
   { destinations(filters: { showInSearch: { eq: true } }, sort: "order:asc") { name slug order showInSearch } }
   ```
   Expect only published `showInSearch: true` rows, ordered by `order`.
5. Confirm `{ home { destinations { name } } }` returns related destinations.

Edge cases: unpublished/draft entries must not appear; `showInSearch: false` rows must be excluded; missing `image` must resolve to `null` (FE handles gracefully).

## ⚠️ Important Note

- _(No breaking changes)_
- **Per-environment config required:** Public read permissions for `Destination` are DB-stored and **not** carried by this PR — enable `find`/`findOne` for the **Public** role in Strapi admin on every environment (local, staging, prod) or GraphQL returns `FORBIDDEN`.
- **Worktree setup (Windows/bun):** this repo uses bun generally, but Strapi worktrees must install with `yarn install --ignore-scripts` then `npm rebuild --foreground-scripts sharp` — bun ignores `yarn.lock` and resolves mismatched Strapi versions (`@strapi/admin` vs `@strapi/design-system` `setOpacity`), breaking the admin build.

_Release note:_ Adds a Destination content type and exposes destinations via GraphQL (collection + `home.destinations`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
